### PR TITLE
Coerce attention mask to bool datatype

### DIFF
--- a/linear_mem_attention_pytorch/linear_mem_attn_torch.py
+++ b/linear_mem_attention_pytorch/linear_mem_attn_torch.py
@@ -30,7 +30,7 @@ def query_chunk_attention(
         attn_weights = torch.einsum("bqhd,bkhd->bqhk", query, key)
         if mask is not None:
             max_neg = -torch.finfo(attn_weights.dtype).max
-            mask = mask.type(torch.bool)
+            if mask.dtype != torch.bool: mask = mask.bool()
             attn_weights.masked_fill_(~mask.unsqueeze(1).unsqueeze(2), max_neg)
 
         max_score = torch.amax(attn_weights, dim=-1, keepdim=True).detach()

--- a/linear_mem_attention_pytorch/linear_mem_attn_torch.py
+++ b/linear_mem_attention_pytorch/linear_mem_attn_torch.py
@@ -30,6 +30,7 @@ def query_chunk_attention(
         attn_weights = torch.einsum("bqhd,bkhd->bqhk", query, key)
         if mask is not None:
             max_neg = -torch.finfo(attn_weights.dtype).max
+            mask = mask.type(torch.bool)
             attn_weights.masked_fill_(~mask.unsqueeze(1).unsqueeze(2), max_neg)
 
         max_score = torch.amax(attn_weights, dim=-1, keepdim=True).detach()


### PR DESCRIPTION
A small fix that allows one to pass in int datatypes when bool is not supported
by the pytorch distributed environment

https://github.com/pytorch/pytorch/issues/32210